### PR TITLE
Removed unused import causing problems: WeightRegularizer

### DIFF
--- a/code/train.py
+++ b/code/train.py
@@ -15,7 +15,6 @@ from keras.layers.core import Dense
 from keras.layers.recurrent import LSTM, GRU, SimpleRNN
 from keras.layers import Input
 from keras.utils.data_utils import get_file
-from keras.regularizers import WeightRegularizer
 from keras.optimizers import Nadam
 from keras.callbacks import EarlyStopping, ModelCheckpoint, ReduceLROnPlateau
 from keras.layers.normalization import BatchNormalization


### PR DESCRIPTION
The WeightRegularizer doesn't seem to exist in the latest version of Keras from git, but fortunately the import was unused anyway. ImportError: cannot import name WeightRegularizer